### PR TITLE
BUG: copy PET files to a temp location for SUV conversion

### DIFF
--- a/DICOMPETSUVPlugin/DICOMPETSUVPlugin.py
+++ b/DICOMPETSUVPlugin/DICOMPETSUVPlugin.py
@@ -157,10 +157,10 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     SUVFactorCalculator = None
     SUVFactorCalculator = slicer.cli.run(slicer.modules.suvfactorcalculator, SUVFactorCalculator, parameters, wait_for_completion=True)
     
+    shutil.rmtree(cliTempDir)
+
     if SUVFactorCalculator.GetStatusString() != 'Completed':
       raise RuntimeError("SUVFactorCalculator CLI did not complete cleanly")
-
-    shutil.rmtree(cliTempDir)
 
     rwvFile = SUVFactorCalculator.GetParameterDefault(1,18)
 


### PR DESCRIPTION
This addresses two critical issues:
 - Windows command line has length limitations at ~8k, which can easily be
   exceeded for whole body DICOM series
 - currently, SUV converter expects that there are no other files than those
   for the series being converted in the directory where they are located (see
   #11). This fix should resolve #11.