### PR TITLE
ENH: Generate PETDICOMExtensionConfig.cmake for find_package visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,4 +29,6 @@ add_subdirectory(DICOMPETSUVPlugin)
 ## NEXT_MODULE
 
 #-----------------------------------------------------------------------------
+
+include(${Slicer_EXTENSION_GENERATE_CONFIG})
 include(${Slicer_EXTENSION_CPACK})


### PR DESCRIPTION
for reference https://discourse.slicer.org/t/nightly-build-tests-failing-for-extensions-with-dependencies-to-other-scriptable-modules/1483