### PR TITLE
Fixing various errors

### DIFF
--- a/DICOMPETSUVPlugin/DICOMPETSUVPlugin.py
+++ b/DICOMPETSUVPlugin/DICOMPETSUVPlugin.py
@@ -4,7 +4,10 @@ from __main__ import vtk, qt, ctk, slicer
 from DICOMLib import DICOMPlugin
 from DICOMLib import DICOMLoadable
 
-import pydicom
+if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+  import pydicom
+else:
+  import dicom
 
 import DICOMLib
 
@@ -102,7 +105,10 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
         if slicer.dicomDatabase.fileValue(fileList[0],self.tags['seriesModality']) == "PT":
           # check if PET series already has Real World Value Mapping
           hasRWVM = False
-          ptFile = pydicom.read_file(fileList[0])
+          if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+            ptFile = pydicom.dcmread(fileList[0])
+          else:
+            ptFile = dicom.read_file(fileList[0])
           studyUID = slicer.dicomDatabase.fileValue(fileList[0],self.tags['studyInstanceUID'])
           for series in slicer.dicomDatabase.seriesForStudy(studyUID):
             if ptFile.SeriesInstanceUID != series:
@@ -169,7 +175,10 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     
   def getReferencedSeriesInstanceUID(self, rwvmFile):
     """Helper method to read the Referenced Series Instance UID from an RWVM file"""
-    dicomFile = pydicom.read_file(rwvmFile)
+    if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+      dicomFile = pydicom.dcmread(rwvmFile)
+    else:
+      dicomFile = dicom.read_file(rwvmFile)
     refSeriesSeq = dicomFile.ReferencedSeriesSequence
     return refSeriesSeq[0].SeriesInstanceUID
    

--- a/DICOMPETSUVPlugin/DICOMPETSUVPlugin.py
+++ b/DICOMPETSUVPlugin/DICOMPETSUVPlugin.py
@@ -25,7 +25,7 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
 
   def __init__(self):
     super(DICOMPETSUVPluginClass,self).__init__()
-    
+
     #print "DICOMPETSUVPlugin __init__()"
     self.loadType = "PET SUV Plugin"
     self.tags['patientID'] = "0010,0020"
@@ -34,16 +34,16 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     self.tags['patientSex'] = "0010,0040"
     self.tags['patientHeight'] = "0010,1020"
     self.tags['patientWeight'] = "0010,1030"
-    
+
     self.tags['relatedSeriesSequence'] = "0008,1250"
-    
+
     self.tags['radioPharmaconStartTime'] = "0018,1072"
     self.tags['decayCorrection'] = "0054,1102"
     self.tags['decayFactor'] = "0054,1321"
     self.tags['frameRefTime'] = "0054,1300"
     self.tags['radionuclideHalfLife'] = "0018,1075"
     self.tags['contentTime'] = "0008,0033"
-    self.tags['seriesTime'] = "0008,0031" 
+    self.tags['seriesTime'] = "0008,0031"
 
 
     self.tags['seriesDescription'] = "0008,103e"
@@ -51,42 +51,42 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     self.tags['seriesInstanceUID'] = "0020,000E"
     self.tags['sopInstanceUID'] = "0008,0018"
     self.tags['seriesInstanceUID'] = "0020,000e"
-  
+
     self.tags['studyInstanceUID'] = "0020,000D"
     self.tags['studyDate'] = "0008,0020"
     self.tags['studyTime'] = "0008,0030"
     self.tags['studyID'] = "0020,0010"
-    
+
     self.tags['rows'] = "0028,0010"
     self.tags['columns'] = "0028,0011"
     self.tags['spacing'] = "0028,0030"
     self.tags['position'] = "0020,0032"
     self.tags['orientation'] = "0020,0037"
     self.tags['pixelData'] = "7fe0,0010"
-    
+
     self.tags['referencedImageRWVMappingSeq'] = "0008,1140"
- 
-    
+
+
     self.fileLists = []
     self.patientName = ""
     self.patientBirthDate = ""
     self.patientSex = ""
-    
+
     self.ctTerm = "CT"
     self.petTerm = "PT"
 
     self.scalarVolumePlugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
     self.rwvPlugin = slicer.modules.dicomPlugins['DICOMRWVMPlugin']()
-  
-  
+
+
   def __getDirectoryOfImageSeries(self, sopInstanceUID):
     f = slicer.dicomDatabase.fileForInstance(sopInstanceUID)
-    return os.path.dirname(f)  
-    
+    return os.path.dirname(f)
+
 
   def __getSeriesInformation(self,seriesFiles,dicomTag):
     if seriesFiles:
-      return  slicer.dicomDatabase.fileValue(seriesFiles[0],dicomTag)          
+      return  slicer.dicomDatabase.fileValue(seriesFiles[0],dicomTag)
 
 
   def examine(self,fileLists):
@@ -95,7 +95,7 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     fileLists parameter.
     """
     loadables = []
-    
+
     # get from cache or create new loadables
     for fileList in fileLists:
       cachedLoadables = self.getCachedLoadables(fileList)
@@ -137,8 +137,8 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
             loadables += loadablesForFiles
 
     return loadables
-    
-  
+
+
   def generateRWVMforFileList(self, fileList):
     """Return a list of loadables after generating Real World Value Mapping
     objects for a PET series
@@ -147,7 +147,7 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     # Call SUV Factor Calculator module
     sopInstanceUID = self.__getSeriesInformation(fileList, self.tags['sopInstanceUID'])
     seriesDirectory = self.__getDirectoryOfImageSeries(sopInstanceUID)
-   
+
     # copy files to a temp location, since otherwise the command line can easily exceed
     #  the maximum on Windows (~8k characters)
     import tempfile, shutil
@@ -162,7 +162,7 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     parameters['PETSeriesInstanceUID'] = self.__getSeriesInformation(fileList, self.tags['seriesInstanceUID'])
     SUVFactorCalculator = None
     SUVFactorCalculator = slicer.cli.run(slicer.modules.suvfactorcalculator, SUVFactorCalculator, parameters, wait_for_completion=True)
-    
+
     shutil.rmtree(cliTempDir)
 
     if SUVFactorCalculator.GetStatusString() != 'Completed':
@@ -172,7 +172,7 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
 
     return rwvFile
 
-    
+
   def getReferencedSeriesInstanceUID(self, rwvmFile):
     """Helper method to read the Referenced Series Instance UID from an RWVM file"""
     if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
@@ -181,11 +181,11 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
       dicomFile = dicom.read_file(rwvmFile)
     refSeriesSeq = dicomFile.ReferencedSeriesSequence
     return refSeriesSeq[0].SeriesInstanceUID
-   
-   
+
+
   def abbreviateLoadableName(self, loadable):
     """Helper method to shorten the name of the SUV conversion """
-    
+
     if "Standardized Uptake Value body weight" in loadable.name:
       loadable.name = (loadable.name).replace('Standardized Uptake Value body weight','(SUVbw)')
       loadable.selected = True
@@ -196,16 +196,16 @@ class DICOMPETSUVPluginClass(DICOMPlugin):
     elif "Standardized Uptake Value body surface area" in loadable.name:
       loadable.name = (loadable.name).replace('Standardized Uptake Value body surface area','(SUVbsa)')
     return
-    
+
 
   def load(self,loadable):
     """Load the series into Slicer"""
-    
+
     # Call the DICOMRWVMPlugin to get the image node
     imageNode = self.rwvPlugin.loadPetSeries(loadable)
     return imageNode
 
-  
+
 #
 # DICOMPETSUVPlugin
 #

--- a/DICOMRWVMPlugin/DICOMRWVMPlugin.py
+++ b/DICOMRWVMPlugin/DICOMRWVMPlugin.py
@@ -1,9 +1,13 @@
 import os
 import sys as SYS
-import pydicom
 from __main__ import vtk, qt, ctk, slicer
 from DICOMLib import DICOMPlugin
 from DICOMLib import DICOMLoadable
+
+if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+  import pydicom
+else:
+  import dicom
 
 import DICOMLib
 
@@ -107,7 +111,10 @@ class DICOMRWVMPluginClass(DICOMPlugin):
     rwvLoadable.patientName = self.__getSeriesInformation(rwvLoadable.files, self.tags['patientName'])
     rwvLoadable.patientID = self.__getSeriesInformation(rwvLoadable.files, self.tags['patientID'])
     rwvLoadable.studyDate = self.__getSeriesInformation(rwvLoadable.files, self.tags['studyDate'])
-    dicomFile = pydicom.read_file(file)
+    if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+      dicomFile = pydicom.dcmread(file)
+    else:
+      dicomFile = dicom.read_file(file)
     rwvmSeq = dicomFile.ReferencedImageRealWorldValueMappingSequence[0].RealWorldValueMappingSequence
     unitsSeq = rwvmSeq[0].MeasurementUnitsCodeSequence
     rwvLoadable.name = rwvLoadable.patientName + ' ' + self.convertStudyDate(rwvLoadable.studyDate) + ' ' + unitsSeq[0].CodeMeaning
@@ -127,7 +134,10 @@ class DICOMRWVMPluginClass(DICOMPlugin):
     """ Returns DICOMLoadable instances associated with an RWVM object."""
 
     newLoadables = []
-    dicomFile = pydicom.read_file(file)
+    if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+      dicomFile = pydicom.dcmread(file)
+    else:
+      dicomFile = dicom.read_file(file)
     if dicomFile.Modality == "RWV":
       refRWVMSeq = dicomFile.ReferencedImageRealWorldValueMappingSequence
       refSeriesSeq = dicomFile.ReferencedSeriesSequence
@@ -166,7 +176,10 @@ class DICOMRWVMPluginClass(DICOMPlugin):
 
           # determine modality of referenced series
           refSeriesFiles = slicer.dicomDatabase.filesForSeries(refSeriesSeq[0].SeriesInstanceUID)
-          refSeriesFile0 = pydicom.read_file(refSeriesFiles[0])
+          if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+            refSeriesFile0 = pydicom.dcmread(refSeriesFiles[0])
+          else:
+            refSeriesFile0 = dicom.read_file(refSeriesFiles[0])
           rwvLoadable.referencedModality = refSeriesFile0.Modality
 
           # add radiopharmaceutical info if PET

--- a/DICOMRWVMPlugin/DICOMRWVMPlugin.py
+++ b/DICOMRWVMPlugin/DICOMRWVMPlugin.py
@@ -212,13 +212,13 @@ class DICOMRWVMPluginClass(DICOMPlugin):
       rwvmSeq = dicomObject.ReferencedImageRealWorldValueMappingSequence[0].RealWorldValueMappingSequence
       unitsSeq = rwvmSeq[0].MeasurementUnitsCodeSequence
       units.SetValueSchemeMeaning(unitsSeq[0].CodeValue, unitsSeq[0].CodingSchemeDesignator, unitsSeq[0].CodeMeaning)
-      
+
       quantitySeq = rwvmSeq[0][0x0040,0x9220]
       for qsItem in quantitySeq:
         if qsItem.ConceptNameCodeSequence[0].CodeMeaning == "Quantity":
           concept = qsItem.ConceptCodeSequence[0]
           quantity.SetValueSchemeMeaning(concept.CodeValue, concept.CodingSchemeDesignator, concept.CodeMeaning)
- 
+
       return (quantity,units)
     except:
       return (None,None)

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Acknowledgements
 This work is funded in part by [Quantitative Imaging to Assess Response in Cancer Therapy Trials][] NIH grant U01-CA140206 (PIs John Buatti, Tom Casavant, Michael Graham, Milan Sonka) and [Quantitative Image Informatics for Cancer Research][] (QIICR) NIH grant U24 CA180918.
 
 [Standardized Uptake Value (SUV)]:http://qibawiki.rsna.org/index.php/Standardized_Uptake_Value_(SUV)
-[Quantitative Imaging to Assess Response in Cancer Therapy Trials]: http://imaging.cancer.gov/programsandresources/specializedinitiatives/qin/iowa 
-[Quantitative Image Informatics for Cancer Research]: http://qiicr.org 
+[Quantitative Imaging to Assess Response in Cancer Therapy Trials]: http://imaging.cancer.gov/programsandresources/specializedinitiatives/qin/iowa
+[Quantitative Image Informatics for Cancer Research]: http://qiicr.org

--- a/SUVFactorCalculatorCLI/SUVFactorCalculator.cxx
+++ b/SUVFactorCalculatorCLI/SUVFactorCalculator.cxx
@@ -78,16 +78,16 @@ since the difference between the time of injection and the acquisition time is
 what is important.
 
 In particular, DO NOT REMOVE THE FOLLOWING DICOM TAGS:
-* Radiopharmaceutical Start Time (0018,1072) 
-* Decay Correction (0054,1102) 
-* Decay Factor (0054,1321) 
-* Frame Reference Time (0054,1300) 
-* Radionuclide Half Life (0018,1075) 
-* Series Time (0008,0031) 
+* Radiopharmaceutical Start Time (0018,1072)
+* Decay Correction (0054,1102)
+* Decay Factor (0054,1321)
+* Frame Reference Time (0054,1300)
+* Radionuclide Half Life (0018,1075)
+* Series Time (0008,0031)
 * Patient's Weight (0010,1030)
 
 Note that to calculate other common SUV values like SUVlbm and SUVbsa, you also
-need to retain: 
+need to retain:
 * Patient's Sex (0010,0040)
 * Patient's Size (0010,1020)
 
@@ -143,16 +143,16 @@ struct parameters
     std::string radionuclideHalfLife;
     std::string frameReferenceTime;
     std::string returnParameterFile;
-    
+
     std::string correctedImage;
 
     double SUVbwConversionFactor;
     double SUVlbmConversionFactor;
     double SUVbsaConversionFactor;
     double SUVibwConversionFactor;
-    
+
     std::vector< std::string > PETFilenames;
-    
+
     std::string RWVMFile;
     short maxPixelValue;
     std::string seriesDescription;
@@ -239,7 +239,7 @@ int LoadImagesAndComputeSUV( parameters & list )
   typedef itk::ImageSeriesReader< VolumeType > VolumeReaderType;
   itk::GDCMImageIO::Pointer dicomIO = itk::GDCMImageIO::New();
   const VolumeReaderType::FileNamesContainer & filenames = inputNames->GetFileNames(selectedSeriesUID);
-  
+
   VolumeReaderType::Pointer volumeReader = VolumeReaderType::New();
   volumeReader->SetImageIO( dicomIO );
   volumeReader->SetFileNames( filenames );
@@ -638,7 +638,7 @@ int LoadImagesAndComputeSUV( parameters & list )
           list.patientWeight = 0.0;
           list.weightUnits = "";
         }
-          
+
       //---
       //--- PatientSize
       if(fileReader.GetElementDS(0x0010,0x1020,1,&list.patientHeight,false) == EXIT_SUCCESS)
@@ -651,7 +651,7 @@ int LoadImagesAndComputeSUV( parameters & list )
           list.patientHeight = 0.0;
           list.heightUnits = "MODULE_INIT_NO_VALUE";
         }
-          
+
       //---
       //--- PatientSex
       if(fileReader.GetElementCS(0x0010,0x0040,tag,false) == EXIT_SUCCESS)
@@ -666,7 +666,7 @@ int LoadImagesAndComputeSUV( parameters & list )
         {
           list.patientSex = "MODULE_INIT_NO_VALUE";
         }
-          
+
       //---
       //--- CorrectedImage
       std::string correctedImage;
@@ -678,7 +678,7 @@ int LoadImagesAndComputeSUV( parameters & list )
         {
           std::cout << "No corrected image detected." << std::endl;
         }
-          
+
       /*//---
       //--- CalibrationFactor
       if(fileReader.GetElementDS(0x7053,0x1009,1,
@@ -724,7 +724,7 @@ int LoadImagesAndComputeSUV( parameters & list )
   if(list.correctedImage.compare("MODULE_INIT_NO_VALUE") != 0)
     {
       std::string correctedImage = list.correctedImage;
-      if(correctedImage.find("ATTN")!=std::string::npos && 
+      if(correctedImage.find("ATTN")!=std::string::npos &&
          (correctedImage.find("DECAY")!=std::string::npos || correctedImage.find("DECY")!=std::string::npos))
         {
           std::cout << "ATTN/DECAY correction detected." << std::endl;
@@ -763,7 +763,7 @@ int LoadImagesAndComputeSUV( parameters & list )
                       double leanBodyMass;    // kg
                       double bodySurfaceArea; // m^2
                       double idealBodyMass;   // kg
-                      
+
                       bodySurfaceArea = (pow(weight,0.425)*pow(height,0.725)*0.007184);
                       list.SUVbsaConversionFactor = bodySurfaceArea / decayedDose;
                       if(list.patientSex=="M")
@@ -771,7 +771,7 @@ int LoadImagesAndComputeSUV( parameters & list )
                           //leanBodyMass = 1.10*weight - 120*(weight/height)*(weight/height);
                           leanBodyMass = 1.10*weight - 128*(weight/height)*(weight/height);  //TODO verify this formula
                           list.SUVlbmConversionFactor = leanBodyMass / decayedDose;
-                          
+
                           idealBodyMass = 48.0 + 1.06*(height - 152);
                           if(idealBodyMass > weight){ idealBodyMass = weight; };
                           list.SUVibwConversionFactor = idealBodyMass / decayedDose;
@@ -780,7 +780,7 @@ int LoadImagesAndComputeSUV( parameters & list )
                         {
                           leanBodyMass = 1.07*weight - 148*(weight/height)*(weight/height);
                           list.SUVlbmConversionFactor = leanBodyMass / decayedDose;
-                          
+
                           idealBodyMass = 45.5 + 0.91*(height - 152);
                           if(idealBodyMass > weight){ idealBodyMass = weight; };
                           list.SUVibwConversionFactor = idealBodyMass / decayedDose;
@@ -809,7 +809,7 @@ int LoadImagesAndComputeSUV( parameters & list )
       std::cout << "No corrected image detected." << std::endl;
       return EXIT_FAILURE;
     }
-  
+
   return EXIT_SUCCESS;
 
 }
@@ -938,22 +938,22 @@ bool ExportRWV(parameters & list,
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptNameCodeSequence,
                          DSRCodedEntryValue("G-C036","SRT","Measurement Method"));
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptCodeSequence,
-                         DSRCodedEntryValue("126410","DCM","SUV body weight calculation method"));    
+                         DSRCodedEntryValue("126410","DCM","SUV body weight calculation method"));
     } else if(measurement.getCodeValue() == "{SUVlbm}g/ml"){
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptNameCodeSequence,
                          DSRCodedEntryValue("G-C036","SRT","Measurement Method"));
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptCodeSequence,
-                         DSRCodedEntryValue("126411","DCM","SUV lean body mass calculation method"));    
+                         DSRCodedEntryValue("126411","DCM","SUV lean body mass calculation method"));
     } else if(measurement.getCodeValue() == "{SUVbsa}cm2/ml"){
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptNameCodeSequence,
                          DSRCodedEntryValue("G-C036","SRT","Measurement Method"));
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptCodeSequence,
-                         DSRCodedEntryValue("126412","DCM","SUV body surface area calculation method"));    
+                         DSRCodedEntryValue("126412","DCM","SUV body surface area calculation method"));
     } else if(measurement.getCodeValue() == "{SUVibw}g/ml"){
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptNameCodeSequence,
                          DSRCodedEntryValue("G-C036","SRT","Measurement Method"));
       InsertCodeSequence(measurementMethodSeqItem, DCM_ConceptCodeSequence,
-                         DSRCodedEntryValue("126413","DCM","SUV ideal body weight calculation method"));    
+                         DSRCodedEntryValue("126413","DCM","SUV ideal body weight calculation method"));
     };
 
     for(unsigned int imageId=0;imageId<instanceUIDs.size();imageId++){
@@ -992,7 +992,7 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
   parameters list;
-  
+
   // ...
   // ... strings used for parsing out DICOM header info
   // ...
@@ -1041,7 +1041,7 @@ int main( int argc, char * argv[] )
       std::vector<std::string> measurementsList;
 
       std::stringstream SUVbwSStream, SUVlbmSStream, SUVbsaSStream, SUVibwSStream;
-      
+
       if(list.SUVbwConversionFactor!=0.0)
         {
           SUVbwSStream << list.SUVbwConversionFactor;
@@ -1068,10 +1068,10 @@ int main( int argc, char * argv[] )
         }
 
       ExportRWV(list, measurementsUnitsList, measurementsList, RWVDICOMPath.c_str());
-      
+
       ofstream writeFile;
       writeFile.open( list.returnParameterFile.c_str() );
-     
+
       writeFile << "radioactivityUnits = " << list.radioactivityUnits.c_str() << std::endl;
       writeFile << "weightUnits = " << list.weightUnits.c_str() << std::endl;
       writeFile << "heightUnits = " << list.heightUnits.c_str() << std::endl;
@@ -1099,7 +1099,7 @@ int main( int argc, char * argv[] )
       std::cout << "SUVlbmConversionFactor = " << list.SUVlbmConversionFactor << std::endl;
       std::cout << "SUVbsaConversionFactor = " << list.SUVbsaConversionFactor << std::endl;
       std::cout << "SUVibwConversionFactor = " << list.SUVibwConversionFactor << std::endl;
-      
+
       } else {
         std::cerr << "ERROR: Failed to compute SUV" << std::endl;
         return EXIT_FAILURE;

--- a/SUVFactorCalculatorCLI/SUVFactorCalculator.xml
+++ b/SUVFactorCalculatorCLI/SUVFactorCalculator.xml
@@ -97,8 +97,8 @@
   <parameters>
     <label>Output</label>
     <description><![CDATA[output]]></description>
-    
-    
+
+
 
     <string>
       <name>radioactivityUnits</name>

--- a/SUVFactorCalculatorCLI/dcmHelpersCommon.cxx
+++ b/SUVFactorCalculatorCLI/dcmHelpersCommon.cxx
@@ -178,7 +178,7 @@ const DcmTagKey dcmHelpersCommon::srDocumentGeneralModuleTags[] = {
 void dcmHelpersCommon::copyElement(const DcmTagKey tag, DcmDataset *src, DcmDataset *dest){
   DcmElement *e;
   OFCondition cond;
-  
+
   cond = src->findAndGetElement(tag, e, OFFalse, OFTrue);
   if(cond.good()){
     cond = dest->insert(e, true);

--- a/Testing/PETDicomExtensionSelfTest.py
+++ b/Testing/PETDicomExtensionSelfTest.py
@@ -161,7 +161,9 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
   def _downloadTestData(self):
     """ download DICOM PET scan and add to DICOM database
     """ 
-    import urllib
+    from six.moves.urllib.parse import urlparse, urlencode
+    from six.moves.urllib.request import urlopen, urlretrieve
+    from six.moves.urllib.error import HTTPError
     quantity = slicer.vtkCodedEntry()
     quantity.SetFromString('CodeValue:126400|CodingSchemeDesignator:DCM|CodeMeaning:Standardized Uptake Value')
     units = slicer.vtkCodedEntry()
@@ -179,7 +181,7 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
       logging.debug('Saving download %s to %s ' % (url, filePath))
       if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
         slicer.util.delayDisplay('Requesting download of %s...\n' % url, 1000)
-        urllib.urlretrieve(url, filePath)
+        urlretrieve(url, filePath)
       if os.path.exists(filePath) and os.path.splitext(filePath)[1]=='.zip':
         success = slicer.app.applicationLogic().Unzip(filePath, destinationDirectory)
         if not success:
@@ -192,8 +194,8 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
   def _loadWithPlugin(self, UID, pluginName):
     dicomWidget = slicer.modules.dicom.widgetRepresentation().self()
     dicomPluginCheckbox =  dicomWidget.detailsPopup.pluginSelector.checkBoxByPlugin
-    dicomPluginStates = {(key,value.checked) for key,value in dicomPluginCheckbox.iteritems()}
-    for cb in dicomPluginCheckbox.itervalues():
+    dicomPluginStates = {(key,value.checked) for key,value in dicomPluginCheckbox.items()}
+    for cb in list(dicomPluginCheckbox.values()):
       cb.checked=False
     dicomPluginCheckbox[pluginName].checked = True
     success=DICOMUtils.loadSeriesByUID([UID])    

--- a/Testing/PETDicomExtensionSelfTest.py
+++ b/Testing/PETDicomExtensionSelfTest.py
@@ -1,9 +1,13 @@
 import os
 import unittest
-import pydicom
 import vtk, qt, ctk, slicer, logging
 from DICOMLib import DICOMUtils
 from slicer.ScriptedLoadableModule import *
+
+if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+  import pydicom
+else:
+  import dicom
 
 #
 # PETDicomExtensionSelfTest
@@ -130,7 +134,10 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     print(RWVMFile)
     
     self.delayDisplay('Testing RealWorldValueSlope stored in RWVM file')
-    rwvm=pydicom.read_file(RWVMFile)
+    if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+      rwvm = pydicom.dcmread(RWVMFile)
+    else:
+      rwvm = dicom.read_file(RWVMFile)
     self.assertIn('ReferencedImageRealWorldValueMappingSequence',  rwvm)
     rirwvms = rwvm.ReferencedImageRealWorldValueMappingSequence[0]
     self.assertIn('RealWorldValueMappingSequence', rirwvms)

--- a/Testing/PETDicomExtensionSelfTest.py
+++ b/Testing/PETDicomExtensionSelfTest.py
@@ -103,7 +103,10 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     """ 
     self.delayDisplay('Checking for PET DICOM plugins')
     dicomWidget = slicer.modules.dicom.widgetRepresentation().self()
-    dicomPluginCheckbox =  dicomWidget.detailsPopup.pluginSelector.checkBoxByPlugin
+    if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+      dicomPluginCheckbox = dicomWidget.browserWidget.pluginSelector.checkBoxByPlugin
+    else:
+      dicomPluginCheckbox = dicomWidget.detailsPopup.pluginSelector.checkBoxByPlugin
     self.assertIn('DICOMPETSUVPlugin', dicomPluginCheckbox)
     self.assertIn('DICOMRWVMPlugin', dicomPluginCheckbox)    
     
@@ -193,7 +196,10 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
   # ------------------------------------------------------------------------------
   def _loadWithPlugin(self, UID, pluginName):
     dicomWidget = slicer.modules.dicom.widgetRepresentation().self()
-    dicomPluginCheckbox =  dicomWidget.detailsPopup.pluginSelector.checkBoxByPlugin
+    if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
+      dicomPluginCheckbox = dicomWidget.browserWidget.pluginSelector.checkBoxByPlugin
+    else:
+      dicomPluginCheckbox = dicomWidget.detailsPopup.pluginSelector.checkBoxByPlugin
     dicomPluginStates = {(key,value.checked) for key,value in dicomPluginCheckbox.items()}
     for cb in list(dicomPluginCheckbox.values()):
       cb.checked=False

--- a/Testing/PETDicomExtensionSelfTest.py
+++ b/Testing/PETDicomExtensionSelfTest.py
@@ -63,7 +63,7 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   """
-    
+
   # ------------------------------------------------------------------------------
   def setUp(self):
     """ Do whatever is needed to reset the state - typically a scene clear will be enough.
@@ -73,23 +73,23 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     self.tempDicomDatabase = os.path.join(slicer.app.temporaryPath,'PETTest')
     slicer.mrmlScene.Clear(0)
     self.originalDicomDatabase = DICOMUtils.openTemporaryDatabase(self.tempDicomDatabase)
-    
+
   # ------------------------------------------------------------------------------
   def doCleanups(self):
     """ cleanup temporary data in case an exception occurs
-    """ 
-    self.tearDown()   
-  
+    """
+    self.tearDown()
+
   # ------------------------------------------------------------------------------
   def tearDown(self):
     """ Close temporary DICOM database and remove temporary data
-    """ 
+    """
     import shutil
     if self.originalDicomDatabase:
       DICOMUtils.closeTemporaryDatabase(self.originalDicomDatabase, True)
       shutil.rmtree(self.tempDicomDatabase) # closeTemporaryDatabase cleanup doesn't work. We need to do it manually
-      self.originalDicomDatabase = None      
-    
+      self.originalDicomDatabase = None
+
   def runTest(self):
     """Run as few or as many tests as needed here.
     """
@@ -99,8 +99,8 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
 
   # ------------------------------------------------------------------------------
   def test_PETDicomExtensionSelfTest_Main(self):
-    """ test PET SUV Plugin and DICOM RWVM creation 
-    """ 
+    """ test PET SUV Plugin and DICOM RWVM creation
+    """
     self.delayDisplay('Checking for PET DICOM plugins')
     dicomWidget = slicer.modules.dicom.widgetRepresentation().self()
     if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
@@ -108,19 +108,19 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     else:
       dicomPluginCheckbox = dicomWidget.detailsPopup.pluginSelector.checkBoxByPlugin
     self.assertIn('DICOMPETSUVPlugin', dicomPluginCheckbox)
-    self.assertIn('DICOMRWVMPlugin', dicomPluginCheckbox)    
-    
+    self.assertIn('DICOMRWVMPlugin', dicomPluginCheckbox)
+
     self.delayDisplay('Adding PET DICOM dataset to DICOM database (including download if necessary)')
     self._downloadTestData()
-    
+
     self.delayDisplay('Loading data with DICOMPETSUVPlugin')
     self._loadWithPlugin(self.UID, 'DICOMPETSUVPlugin')
     imageNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLScalarVolumeNode')
     self.assertIsNotNone(imageNode)
-    
+
     self.delayDisplay('Testing properties of loaded SUV normalized data')
     self._testDataProperties(imageNode)
-    
+
     self.delayDisplay('Testing DICOM database for created RWVM file')
     patientUID = DICOMUtils.getDatabasePatientUIDByPatientName(self.PatientName)
     studies = slicer.dicomDatabase.studiesForPatient(patientUID)
@@ -135,7 +135,7 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     self.assertTrue(len(files)>0)
     RWVMFile = files[0]
     print(RWVMFile)
-    
+
     self.delayDisplay('Testing RealWorldValueSlope stored in RWVM file')
     if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
       rwvm = pydicom.dcmread(RWVMFile)
@@ -148,29 +148,29 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     self.assertIn('RealWorldValueSlope', rwvms)
     slope = rwvms.RealWorldValueSlope
     self.assertTrue(abs(slope-0.000401664)<0.00001)
-    
+
     self.delayDisplay('Loading data with DICOMRWVMPlugin')
     slicer.mrmlScene.Clear(0)
     self._loadWithPlugin(RWVMSeries, 'DICOMRWVMPlugin')
     imageNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLScalarVolumeNode')
     self.assertIsNotNone(imageNode)
-    
+
     self.delayDisplay('Testing properties of loaded SUV normalized data')
     self._testDataProperties(imageNode)
-        
+
     self.delayDisplay('Test passed!')
-      
+
   # ------------------------------------------------------------------------------
   def _downloadTestData(self):
     """ download DICOM PET scan and add to DICOM database
-    """ 
+    """
     from six.moves.urllib.parse import urlparse, urlencode
     from six.moves.urllib.request import urlopen, urlretrieve
     from six.moves.urllib.error import HTTPError
     quantity = slicer.vtkCodedEntry()
     quantity.SetFromString('CodeValue:126400|CodingSchemeDesignator:DCM|CodeMeaning:Standardized Uptake Value')
     units = slicer.vtkCodedEntry()
-    units.SetFromString('CodeValue:{SUVbw}g/ml|CodingSchemeDesignator:UCUM|CodeMeaning:Standardized Uptake Value body weight')      
+    units.SetFromString('CodeValue:{SUVbw}g/ml|CodingSchemeDesignator:UCUM|CodeMeaning:Standardized Uptake Value body weight')
     url = 'http://slicer.kitware.com/midas3/download/item/257234/QIN-HEADNECK-01-0139-PET.zip'
     zipFile = 'QIN-HEADNECK-01-0139-PET.zip'
     suvNormalizationFactor = 0.00040166400000000007
@@ -192,7 +192,7 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
       indexer = ctk.ctkDICOMIndexer()
       indexer.addDirectory(slicer.dicomDatabase, destinationDirectory, None)
       indexer.waitForImportFinished()
-    
+
   # ------------------------------------------------------------------------------
   def _loadWithPlugin(self, UID, pluginName):
     dicomWidget = slicer.modules.dicom.widgetRepresentation().self()
@@ -204,10 +204,10 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     for cb in list(dicomPluginCheckbox.values()):
       cb.checked=False
     dicomPluginCheckbox[pluginName].checked = True
-    success=DICOMUtils.loadSeriesByUID([UID])    
+    success=DICOMUtils.loadSeriesByUID([UID])
     for key,value in dicomPluginStates:
       dicomPluginCheckbox[key].checked=value
-  
+
   # ------------------------------------------------------------------------------
   def _testDataProperties(self, imageNode):
     units = imageNode.GetVoxelValueUnits()
@@ -221,6 +221,6 @@ class PETDicomExtensionSelfTestTest(ScriptedLoadableModuleTest):
     scalarRange = imageNode.GetImageData().GetScalarRange()
     self.assertTrue(abs(scalarRange[0]-0)<0.01)
     self.assertTrue(abs(scalarRange[1]-89.85876418551707)<0.01)
-    
-    
-    
+
+
+


### PR DESCRIPTION
This PR aims to fix various issues as part of trying to fix a [failing test](http://slicer.cdash.org/testDetails.php?test=9858014&build=1784832).  Many things were not API compatible between Slicer 4.10 stable and Slicer 4.11 preview. 

On my local machine, the test is still failing using Slicer 4.11 preview and I'm not sure what is wrong, but the traceback error is occurring within DICOMUtils.
```log
Traceback (most recent call last):
  File "C:/D/Slicer-PETDICOMExtension-bin/lib/Slicer-4.11/qt-scripted-modules/PETDicomExtensionSelfTest.py", line 117, in test_PETDicomExtensionSelfTest_Main
    self._loadWithPlugin(self.UID, 'DICOMPETSUVPlugin')
  File "C:/D/Slicer-PETDICOMExtension-bin/lib/Slicer-4.11/qt-scripted-modules/PETDicomExtensionSelfTest.py", line 208, in _loadWithPlugin
    success=DICOMUtils.loadSeriesByUID([uid])
  File "C:\S5R\Slicer-build\lib\Slicer-4.11\qt-scripted-modules\DICOMLib\DICOMUtils.py", line 141, in loadSeriesByUID
    loadedNodeIDs = loadLoadables(loadablesByPlugin)
  File "C:\S5R\Slicer-build\lib\Slicer-4.11\qt-scripted-modules\DICOMLib\DICOMUtils.py", line 658, in loadLoadables
    cancelled = progressCallback("{0} ({1})".format(loadable.name, derivedItem), step*100/len(selectedLoadables))
TypeError: 'NoneType' object is not callable
```

Those with push access (@fedorov , @pieper , @chribaue ) can you review and merge? Thanks!