### PR TITLE
COMP: fix build errors, vtk9 change

### DIFF
--- a/SUVFactorCalculatorCLI/CMakeLists.txt
+++ b/SUVFactorCalculatorCLI/CMakeLists.txt
@@ -48,10 +48,13 @@ set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
   ${DCMTK_LIBRARIES}
-  vtkIOCore
   vtkITK
   ITKIODCMTK
   )
+
+if("${Slicer_VTK_VERSION_MAJOR}" MATCHES "8")
+  list(APPEND MODULE_TARGET_LIBRARIES vtkIOCore)
+endif()
 
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(

--- a/SUVFactorCalculatorCLI/SUVFactorCalculator.cxx
+++ b/SUVFactorCalculatorCLI/SUVFactorCalculator.cxx
@@ -1069,7 +1069,7 @@ int main( int argc, char * argv[] )
 
       ExportRWV(list, measurementsUnitsList, measurementsList, RWVDICOMPath.c_str());
 
-      ofstream writeFile;
+      std::ofstream writeFile;
       writeFile.open( list.returnParameterFile.c_str() );
 
       writeFile << "radioactivityUnits = " << list.radioactivityUnits.c_str() << std::endl;


### PR DESCRIPTION
Add std:: namespace qualifier for ofstring and make
vtkIOCore conditional for vtk8 only.