### PR TITLE
BUG: remove old VTK version check

### DIFF
--- a/DICOMRWVMPlugin/DICOMRWVMPlugin.py
+++ b/DICOMRWVMPlugin/DICOMRWVMPlugin.py
@@ -256,10 +256,7 @@ class DICOMRWVMPluginClass(DICOMPlugin):
       multiplier = vtk.vtkImageMathematics()
       multiplier.SetOperationToMultiplyByK()
       multiplier.SetConstantK(float(conversionFactor))
-      if vtk.VTK_MAJOR_VERSION <= 5:
-        multiplier.SetInput1(imageNode.GetImageData())
-      else:
-        multiplier.SetInput1Data(imageNode.GetImageData())
+      multiplier.SetInput1Data(imageNode.GetImageData())
       multiplier.Update()
       imageNode.GetImageData().DeepCopy(multiplier.GetOutput())
 


### PR DESCRIPTION
The version variable no longer exists in new vtk and the version
it was checking for is no longer supported by Slicer anyway.